### PR TITLE
Use callback function instead of "key", "value" in Collection#find

### DIFF
--- a/commands/ban.js
+++ b/commands/ban.js
@@ -27,7 +27,7 @@ module.exports.run = async (bot, message, args) => {
       .addField("Ekkor", message.createdAt)
       .addField("Indok", bReason);
 
-      let banChannel = message.guild.channels.find(`name`, "parancsok");
+      let banChannel = message.guild.channels.find(c => c.name === "parancsok");
       if (!banChannel) return message.channel.send("A megadott csatorna nem található!");
 
       message.guild.member(bUser).ban(bReason);

--- a/commands/kick.js
+++ b/commands/kick.js
@@ -27,7 +27,7 @@ module.exports.run = async (bot, message, args) => {
       .addField("Ekkor", message.createdAt)
       .addField("Indok", kReason);
 
-      let kickChannel = message.guild.channels.find(`name`, "parancsok");
+      let kickChannel = message.guild.channels.find(c => c.name ==="parancsok");
       if (!kickChannel) return message.channel.send("Nem található a csatorna!");
 
       message.guild.member(kUser).kick(kReason);

--- a/commands/report.js
+++ b/commands/report.js
@@ -17,7 +17,7 @@ module.exports.run = async (bot, message, args) => {
       .addField("Idő", message.createdAt)
       .addField("Ok: ", rReason);
 
-      let reportschannel = message.guild.channels.find(`name`, "parancsok");
+      let reportschannel = message.guild.channels.find(c => c.name === "parancsok");
       if (!reportschannel) return message.channel.send("Couldn't find the specific channel");
       message.delete().catch(O_o=>{});
       reportschannel.send(reportEmbed);

--- a/commands/tempmute.js
+++ b/commands/tempmute.js
@@ -9,7 +9,7 @@ module.exports.run = async (bot, message, args) => {
   if (!tomute) return message.reply("Couldn't find user.");
   if(tomute.hasPermission("MANAGE_MESSAGES")) return message.reply("Can't mute them.");
 
-  let muterole = message.guild.roles.find("name", "muted");
+  let muterole = message.guild.roles.find(r => r.name === "muted");
   //start to create a role
   if (!muterole){
     try {


### PR DESCRIPTION
In some of the files you're using the `"key", "value"`-way of calling Collection#find:
```js
collection.find("name", "value");
```
This is deprecated and will be removed soon (you should be getting Deprecation warnings in your console). This pull request replaces all occurences with the new way: specifying a callback function:
```js
collection.find(c => c.name === "value");
```